### PR TITLE
add(examples): aws-lambda-tailscale-webhook example

### DIFF
--- a/examples/aws-lambda-tailscale-webhook/.github/workflows/terraform.yml
+++ b/examples/aws-lambda-tailscale-webhook/.github/workflows/terraform.yml
@@ -1,0 +1,90 @@
+name: deploy.terraform-aws-okta-webhooks
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  terraform:
+    name: 'Terraform'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }} # if you have/need it
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Terraform Format
+        id: fmt
+        run: terraform fmt -check -diff
+
+      - name: Build Webhook (terraform-aws-okta-pull-webhook)
+        run: cd terraform-aws-okta-pull-webhook && npm run deploy:prepare && npm install && npm run build
+
+      - name: Build Webhook (terraform-aws-okta-webhook)
+        run: cd terraform-aws-okta-webhook && npm run deploy:prepare && npm install && npm run build
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Plan
+        id: plan
+        if: github.event_name == 'pull_request'
+        run: terraform plan -input=false -no-color
+        continue-on-error: true
+        env:
+          TF_VAR_indent_webhook_secret: ${{ secrets.INDENT_WEBHOOK_SECRET }}
+          TF_VAR_indent_pull_webhook_secret: ${{ secrets.INDENT_PULL_WEBHOOK_SECRET }}
+          TF_VAR_okta_domain: ${{ secrets.OKTA_DOMAIN }}
+          TF_VAR_okta_token: ${{ secrets.OKTA_TOKEN }}
+          TF_VAR_okta_client_id: ${{ secrets.OKTA_CLIENT_ID }}
+          TF_VAR_okta_private_key: ${{ secrets.OKTA_PRIVATE_KEY }}
+          TF_VAR_okta_slack_app_id: ${{ secrets.OKTA_SLACK_APP_ID }}
+
+      - uses: actions/github-script@0.9.0
+        if: github.event_name == 'pull_request'
+        env:
+          PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+            #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+            #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+            <details><summary>Show Plan</summary>
+            \`\`\`${process.env.PLAN}\`\`\`
+            </details>
+            *Actor: @${{ github.actor }}, Event: \`${{ github.event_name }}\`*`;
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+      - name: Terraform Plan Status
+        if: steps.plan.outcome == 'failure'
+        run: exit 1
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: terraform apply -input=false -auto-approve
+        env:
+          TF_VAR_indent_webhook_secret: ${{ secrets.INDENT_WEBHOOK_SECRET }}
+          TF_VAR_indent_pull_webhook_secret: ${{ secrets.INDENT_PULL_WEBHOOK_SECRET }}
+          TF_VAR_okta_domain: ${{ secrets.OKTA_DOMAIN }}
+          TF_VAR_okta_token: ${{ secrets.OKTA_TOKEN }}
+          TF_VAR_okta_client_id: ${{ secrets.OKTA_CLIENT_ID }}
+          TF_VAR_okta_private_key: ${{ secrets.OKTA_PRIVATE_KEY }}
+          TF_VAR_okta_slack_app_id: ${{ secrets.OKTA_SLACK_APP_ID }}

--- a/examples/aws-lambda-tailscale-webhook/.gitignore
+++ b/examples/aws-lambda-tailscale-webhook/.gitignore
@@ -1,0 +1,12 @@
+data
+dist
+lib
+.env
+node_modules
+*.tfstate
+.terraform*
+*.tfstate.*
+terraform/config/*.tfvars
+!terraform/config/example.tfvars
+yarn.lock
+package-lock.json

--- a/examples/aws-lambda-tailscale-webhook/README.md
+++ b/examples/aws-lambda-tailscale-webhook/README.md
@@ -1,0 +1,26 @@
+# Indent + AWS and Tailscale Webhooks
+
+This repository contains two webhooks (AWS Lambdas) to pull and apply updates to Tailscale Groups using [Indent](https://indent.com/docs).
+
+## Configuration
+
+Before you deploy these webhooks for the first time, [create an S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) to use to store Terraform state, add your credentials as [GitHub Secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets)
+
+### Actions secrets
+
+Add the credentials below to your GitHub Secrets:
+
+| Name                          | Value                                                                                                                                                                                                                                                                |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TAILSCALE_WEBHOOK_SECRET      | Get this from your [Indent App](https://indent.com/spaces?next=/manage/spaces/%5Bspace%5D/apps/) or an [Indent Webhook](https://indent.com/docs/webhooks/deploy/okta-groups) in the Dashboard.                                                                       |
+| TAILSCALE_PULL_WEBHOOK_SECRET | Get this from the [Indent Webhook](https://indent.com/docs/webhooks/deploy/okta-groups#step-1-deploy-the-pull-update-webhook) you created while setting up your space.                                                                                               |
+| TAILSCALE_API_KEY             | Your Tailscale API Key. Get this from your [Tailscale Administrator Panel](https://login.tailscale.com/admin/settings/keys).                                                                                                                                         |
+| TAILSCALE_TAILNET             | The name of your Tailscale network. The network you want to manage with Indent.                                                                                                                                                                                      |
+| AWS_REGION                    | The AWS Region where you want to deploy the webhooks.                                                                                                                                                                                                                |
+| AWS_ACCESS_KEY_ID             | [Your Programmatic AWS Access Key ID](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)                                                                                                                      |
+| AWS_SECRET_ACCESS_KEY         | [Your Programmatic AWS Secret Access Key](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys)                                                                                                                  |
+| AWS_SESSION_TOKEN             | Optional: [Your AWS Session Token](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html#using-temp-creds-sdk-cli). **Note: If you use an AWS Session ID you will need to update it for each deployment once the session expires** |
+
+## Deployment
+
+This repository auto-deploys to AWS when you push or merge PRs to the `main` branch. You can manually redeploy the webhooks by re-running the [latest GitHub Action job](https://docs.github.com/en/actions/managing-workflow-runs/re-running-workflows-and-jobs).

--- a/examples/aws-lambda-tailscale-webhook/main.tf
+++ b/examples/aws-lambda-tailscale-webhook/main.tf
@@ -1,0 +1,24 @@
+terraform {
+  backend "s3" {
+    encrypt = true
+    bucket  = ""
+    region  = "us-west-2"
+    key     = "indent/terraform.tfstate"
+  }
+}
+
+module "tailscale-pull-webhook" {
+  source                = "./terraform-aws-tailscale-webhook/terraform"
+
+  indent_webhook_secret = var.tailscale_pull_webhook_secret
+  tailscale_api_key     = var.tailscale_api_key
+  tailscale_tailnet     = var.tailscale_tailnet
+}
+
+module "tailscale-change-webhook" {
+  source                = "./terraform-aws-tailscale-webhook/terraform"
+
+  indent_webhook_secret = var.tailscale_pull_webhook_secret
+  tailscale_api_key     = var.tailscale_api_key
+  tailscale_tailnet     = var.tailscale_tailnet
+}

--- a/examples/aws-lambda-tailscale-webhook/outputs.tf
+++ b/examples/aws-lambda-tailscale-webhook/outputs.tf
@@ -1,0 +1,9 @@
+output "pull_api_base_url" {
+  value       = module.tailscale-pull-webhook.api_base_url
+  description = "The URL of the deployed Lambda"
+}
+
+output "api_base_url" {
+  value       = module.tailscale-change-webhook.api_base_url
+  description = "The URL of the deployed Lambda"
+}

--- a/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/.gitignore
+++ b/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/.gitignore
@@ -1,0 +1,10 @@
+data
+dist
+lib
+.env
+node_modules
+*.tfstate
+.terraform
+*.tfstate.*
+terraform/config/*.tfvars
+!terraform/config/example.tfvars

--- a/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/package.json
+++ b/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@indent/template-terraform-aws-tailscale-webhook",
+  "version": "0.0.0",
+  "description": "A Node.js starter for Terraform on AWS with Indent and Tailscale.",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "build": "tsc",
+    "clean:dist": "rm -rf dist",
+    "clean:modules": "rm -rf node_modules",
+    "clean:tf": "rm -rf terraform/.terraform && rm -rf terraform/terraform.tfstate*",
+    "clean:all": "npm run clean:dist; npm run clean:tf; npm run clean:modules",
+    "create:all": "npm run deploy:init; npm run deploy:prepare; npm run deploy:all",
+    "deploy:init": "cd terraform; terraform init",
+    "deploy:prepare": "npm install --production && ./scripts/build-layers.sh",
+    "deploy:all": "npm run build && npm run tf:apply -auto-approve",
+    "destroy:all": "npm run tf:destroy -auto-approve",
+    "tf:plan": "cd terraform && terraform plan -var-file ./config/terraform.tfvars",
+    "tf:apply": "cd terraform && terraform apply -compact-warnings -var-file ./config/terraform.tfvars",
+    "tf:destroy": "cd terraform && terraform destroy -auto-approve -var-file ./config/terraform.tfvars"
+  },
+  "author": "Indent Inc <open@indent.com>",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git"
+  },
+  "devDependencies": {
+    "@types/aws-lambda": "^8.10.39",
+    "@types/node": "^13.9.8",
+    "@types/node-fetch": "^2.5.5",
+    "ts-loader": "^6.2.2",
+    "typescript": "^3.8.3",
+  },
+  "dependencies": {
+    "@indent/tailscale-webhook": "latest",
+    "@indent/provider-aws": "latest",
+    "@indent/webhook": "latest",
+    "@indent/types": "latest",
+    "ts-node": "^8.5.4"
+  }
+}

--- a/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/scripts/build-layers.sh
+++ b/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/scripts/build-layers.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -x
+set -e
+
+ROOT_DIR="$(pwd)"
+
+OUTPUT_DIR="$(pwd)/dist"
+
+LAYER_DIR=$OUTPUT_DIR/layers/nodejs
+
+mkdir -p $LAYER_DIR
+
+cp -LR node_modules $LAYER_DIR
+
+cd $OUTPUT_DIR/layers
+
+zip -q -r layers.zip nodejs

--- a/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/src/index.ts
+++ b/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/src/index.ts
@@ -1,0 +1,6 @@
+import { getLambdaHandler } from '@indent/provider-aws'
+import { TailscaleIntegration } from '@indent/tailscale-webhook'
+
+export const handle = getLambdaHandler({
+  integrations: [new TailscaleIntegration()],
+})

--- a/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/apiGateway.tf
+++ b/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/apiGateway.tf
@@ -1,0 +1,64 @@
+resource "aws_api_gateway_rest_api" "api_gateway_rest_api" {
+  name        = "api_gateway"
+  description = "Api Gateway for indent-aws-tailscale-pull-webhook"
+}
+
+resource "aws_api_gateway_resource" "api_gateway" {
+  rest_api_id = aws_api_gateway_rest_api.api_gateway_rest_api.id
+  parent_id   = aws_api_gateway_rest_api.api_gateway_rest_api.root_resource_id
+  path_part   = "{proxy+}"
+}
+
+resource "aws_api_gateway_method" "api_gateway_method" {
+  rest_api_id   = aws_api_gateway_rest_api.api_gateway_rest_api.id
+  resource_id   = aws_api_gateway_resource.api_gateway.id
+  http_method   = "ANY"
+  authorization = "NONE"
+
+  request_parameters = {
+    "method.request.header.x-indent-signature" = true
+    "method.request.header.x-indent-timestamp" = true
+  }
+}
+
+resource "aws_api_gateway_integration" "api_gateway_integration" {
+  rest_api_id = aws_api_gateway_rest_api.api_gateway_rest_api.id
+  resource_id = aws_api_gateway_method.api_gateway_method.resource_id
+  http_method = aws_api_gateway_method.api_gateway_method.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.lambda.invoke_arn
+}
+
+resource "aws_api_gateway_method" "api_gateway_root_method" {
+  rest_api_id   = aws_api_gateway_rest_api.api_gateway_rest_api.id
+  resource_id   = aws_api_gateway_rest_api.api_gateway_rest_api.root_resource_id
+  http_method   = "ANY"
+  authorization = "NONE"
+
+  request_parameters = {
+    "method.request.header.x-indent-signature" = true
+    "method.request.header.x-indent-timestamp" = true
+  }
+}
+
+resource "aws_api_gateway_integration" "api_gateway_root_integration" {
+  rest_api_id = aws_api_gateway_rest_api.api_gateway_rest_api.id
+  resource_id = aws_api_gateway_method.api_gateway_root_method.resource_id
+  http_method = aws_api_gateway_method.api_gateway_root_method.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.lambda.invoke_arn
+}
+
+resource "aws_api_gateway_deployment" "api_gateway_deployment" {
+  depends_on = [
+    aws_api_gateway_integration.api_gateway_integration,
+    aws_api_gateway_integration.api_gateway_root_integration,
+  ]
+
+  rest_api_id = aws_api_gateway_rest_api.api_gateway_rest_api.id
+  stage_name  = "dev"
+}

--- a/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/config/example.tfvars
+++ b/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/config/example.tfvars
@@ -1,0 +1,8 @@
+# Indent Webhook Secret is used to verify messages from Indent
+indent_webhook_secret = ""
+
+# Tailscale API Key - Create this in the admin console
+tailscale_api_key = ""
+
+# Tailnet - This is usually the email address you used to create your Tailscale account
+tailscale_tailnet = ""

--- a/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/iam.tf
+++ b/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/iam.tf
@@ -1,0 +1,66 @@
+data "aws_iam_policy_document" "lambda_assume_role_document" {
+  version = "2012-10-17"
+
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+
+    effect = "Allow"
+  }
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "lambda_document" {
+  version = "2012-10-17"
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "cloudwatch:PutMetricData",
+    ]
+
+    resources = ["arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${local.name}:*"]
+  }
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "iam:ListGroupsForUser",
+      "iam:ListUsers",
+      "iam:ListGroups",
+      "iam:GetGroup",
+      "iam:GetUser",
+    ]
+
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:*"]
+  }
+}
+
+resource "aws_iam_policy" "lambda_policy" {
+  policy = data.aws_iam_policy_document.lambda_document.json
+}
+
+resource "aws_iam_role" "lambda_role" {
+  name               = "${local.name}-role"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role_document.json
+
+  tags = local.tags
+}
+
+resource "aws_iam_policy_attachment" "lambda_attachment" {
+  name = "${local.name}-attachment"
+
+  roles = [aws_iam_role.lambda_role.name]
+
+  policy_arn = aws_iam_policy.lambda_policy.arn
+}

--- a/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/lambda.tf
+++ b/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/lambda.tf
@@ -1,0 +1,44 @@
+data "archive_file" "function_archive" {
+  type        = "zip"
+  source_dir  = "${path.module}/../lib"
+  output_path = "${path.module}/../dist/function.zip"
+}
+
+resource "aws_lambda_layer_version" "deps" {
+  compatible_runtimes = ["nodejs14.x"]
+  layer_name          = "${local.name}-dependency_layer"
+  filename            = "${path.module}/../dist/layers/layers.zip"
+  source_code_hash    = filesha256("${path.module}/../dist/layers/layers.zip")
+}
+
+resource "aws_lambda_function" "lambda" {
+  function_name    = local.name
+  role             = aws_iam_role.lambda_role.arn
+  filename         = data.archive_file.function_archive.output_path
+  source_code_hash = data.archive_file.function_archive.output_base64sha256
+  memory_size      = local.lambda_memory
+  handler          = "index.handle"
+  runtime          = "nodejs14.x"
+  timeout          = "30"
+
+  layers = [aws_lambda_layer_version.deps.arn]
+
+  environment {
+    variables = {
+      "INDENT_WEBHOOK_SECRET" = var.indent_webhook_secret
+      "TAILSCALE_TAILNET"     = var.tailscale_tailnet
+      "TAILSCALE_API_KEY"     = var.tailscale_api_key
+    }
+  }
+}
+
+resource "aws_lambda_permission" "lambda" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.lambda.function_name
+  principal     = "apigateway.amazonaws.com"
+
+  # The "/*/*" portion grants access from any method on any resource
+  # within the API Gateway REST API.
+  source_arn = "${aws_api_gateway_rest_api.api_gateway_rest_api.execution_arn}/*/*"
+}

--- a/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/locals.tf
+++ b/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/locals.tf
@@ -1,0 +1,16 @@
+locals {
+  name          = "indent-aws-tscale-webhook-${random_string.suffix.result}"
+  lambda_memory = 128
+
+  tags = {
+    Name       = "Indent + Tailscale on AWS via Terraform"
+    GitRepo    = "https://github.com/indentapis/examples"
+    ProvidedBy = "Indent"
+  }
+}
+
+resource "random_string" "suffix" {
+  length  = 4
+  upper   = false
+  special = false
+}

--- a/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/outputs.tf
+++ b/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "api_base_url" {
+  value       = aws_api_gateway_deployment.api_gateway_deployment.invoke_url
+  description = "The URL of the deployed Lambda"
+}

--- a/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/provider.tf
+++ b/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/provider.tf
@@ -1,0 +1,17 @@
+provider "aws" {
+  profile     = var.aws_profile
+  region      = var.aws_region
+  max_retries = 1
+}
+
+terraform {
+  required_providers {
+    random = {
+      source = "hashicorp/random"
+    }
+
+    aws = {
+      version = "~> 3.0"
+    }
+  }
+}

--- a/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/variables.tf
+++ b/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/terraform/variables.tf
@@ -1,0 +1,27 @@
+variable "aws_region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "aws_profile" {
+  type    = string
+  default = "default"
+}
+
+variable "indent_webhook_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "tailscale_api_key" {
+  description = "Your Tailscale API Key"
+  type        = string
+  sensitive   = true
+}
+
+variable "tailscale_tailnet" {
+  description = "The Tailnet where you want to manage ACLs"
+  type        = string
+  sensitive   = true
+}
+

--- a/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/tsconfig.json
+++ b/examples/aws-lambda-tailscale-webhook/terraform-aws-tailscale-webhook/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "lib": ["esnext", "dom"],
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "noUnusedParameters": true,
+    "noUnusedLocals": true,
+    "sourceMap": true,
+    "target": "esnext",
+    "outDir": "lib"
+  },
+  "include": ["./src/**/*"]
+}

--- a/examples/aws-lambda-tailscale-webhook/variables.tf
+++ b/examples/aws-lambda-tailscale-webhook/variables.tf
@@ -1,0 +1,31 @@
+variable "aws_region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "aws_profile" {
+  type    = string
+  default = "default"
+}
+
+variable "tailscale_webhook_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "tailscale_pull_webhook_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "tailscale_api_key" {
+  type      = string
+  default   = ""
+  sensitive = true
+}
+
+variable "tailscale_tailnet" {
+  type      = string
+  default   = ""
+  sensitive = true
+}


### PR DESCRIPTION
Adds `tailscale` as a code example.

See [PR #54](https://github.com/indentinc/indent-docs/pull/54) from `indentinc/indent-docs`