### PR TITLE
fix(examples/.github/workflows): env vars for 'terraform output'

### DIFF
--- a/templates/scripts/steps/github-action.ts
+++ b/templates/scripts/steps/github-action.ts
@@ -32,6 +32,8 @@ export async function writeGithubAction(currentItem: CatalogItem, WEBHOOK_DIR) {
               step.name === 'Terraform Apply'
             ) {
               step.env = githubSecrets
+            } else if (step.name === 'Terraform Output') {
+              step.env = githubSecrets
             }
           }
         })


### PR DESCRIPTION
Adds environment variables to the `terraform output` step