### PR TITLE
fix(terraform): support workflow_dispatch events

### DIFF
--- a/templates/example/.github/workflows/deploy.example.yaml
+++ b/templates/example/.github/workflows/deploy.example.yaml
@@ -77,14 +77,14 @@ jobs:
         run: exit 1
 
       - name: Terraform Apply
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: terraform apply -input=false -auto-approve
         env:
           TF_VAR_indent_webhook_secret: ${{ secrets.INDENT_WEBHOOK_SECRET }}
           TF_VAR_example_api_key: ${{ secrets.EXAMPLE_API_KEY}}
       
       - name: Terraform Output
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: terraform output
         env:
           TF_VAR_indent_webhook_secret: ${{ secrets.INDENT_WEBHOOK_SECRET }}


### PR DESCRIPTION
Update the example deploy.yaml to recognize workflow_dispatch events. This would allow manually triggered jobs to successfully deploy.